### PR TITLE
feat: filter the return-type based on composite key structure in single-table design

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import type { AWSError, DynamoDB, Request } from "aws-sdk";
 import { Callback } from "./callback";
 import { DeleteItemInput, DeleteItemOutput } from "./delete-item";
 import { GetItemInput, GetItemOutput } from "./get-item";
+import { KeyAttribute } from "./key";
 import { PutItemInput, PutItemOutput } from "./put-item";
 import { QueryInput, QueryOutput } from "./query";
 
@@ -11,22 +12,24 @@ export interface TypeSafeDynamoDB<
   RangeKey extends keyof Item | undefined = undefined
 > extends Omit<DynamoDB, "getItem" | "deleteItem" | "putItem" | "query"> {
   getItem<
+    Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
     AttributesToGet extends keyof Item | undefined = undefined,
     ProjectionExpression extends string | undefined = undefined
   >(
     params: GetItemInput<
       Item,
+      Key,
       PartitionKey,
       RangeKey,
       AttributesToGet,
       ProjectionExpression
     >,
     callback?: Callback<
-      GetItemOutput<Item, AttributesToGet, ProjectionExpression>,
+      GetItemOutput<Item, Key, AttributesToGet, ProjectionExpression>,
       AWSError
     >
   ): Request<
-    GetItemOutput<Item, AttributesToGet, ProjectionExpression>,
+    GetItemOutput<Item, Key, AttributesToGet, ProjectionExpression>,
     AWSError
   >;
 

--- a/src/key.ts
+++ b/src/key.ts
@@ -1,4 +1,4 @@
-import { M, ToAttributeValue } from "./attribute-value";
+import { B, M, N, S, ToAttributeValue } from "./attribute-value";
 
 export type Key<
   Item extends object,
@@ -11,3 +11,16 @@ export type KeyAttribute<
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined
 > = Extract<ToAttributeValue<Key<Item, PartitionKey, RangeKey>>, M>["M"];
+
+export type KeyAttributeToObject<
+  Item extends object,
+  Key extends KeyAttribute<Item, keyof Item, keyof Item | undefined>
+> = {
+  [attrName in keyof Key]: Key[attrName] extends S<infer s>
+    ? s
+    : Key[attrName] extends N<infer n>
+    ? n
+    : Key[attrName] extends B
+    ? Buffer | string
+    : never;
+};

--- a/test/dummy.test.ts
+++ b/test/dummy.test.ts
@@ -177,7 +177,7 @@ export async function getProfile(userId: String) {
     .promise();
 
   profile.Item?.FullName;
-  // @ts-expect-error - OrderID is only available when SK is prefixed with `#ORDER`
+  // @ts-expect-error
   profile.Item?.OrderID;
 }
 
@@ -197,6 +197,6 @@ export async function getOrder(userId: string, orderId: string) {
     .promise();
 
   order.Item?.OrderID;
-  // @ts-expect-error - FullName is only available when SK is prefixed with `#PROFILE`
+  // @ts-expect-error
   order.Item?.FullName;
 }

--- a/test/dummy.test.ts
+++ b/test/dummy.test.ts
@@ -133,3 +133,70 @@ export async function foo() {
   a6.tuple[0];
   a6.tuple[1];
 }
+
+const TableName = "test";
+
+interface User<UserID extends string = string> {
+  PK: `USER#${UserID}`;
+  SK: `#PROFILE#${UserID}`;
+  Username: string;
+  FullName: string;
+  Email: string;
+  CreatedAt: Date;
+  Address: string;
+}
+
+interface Order<
+  UserID extends string = string,
+  OrderID extends string = string
+> {
+  PK: `USER#${UserID}`;
+  SK: `ORDER#${OrderID}`;
+  Username: string;
+  OrderID: string;
+  Status: "PLACED" | "SHIPPED";
+  CreatedAt: Date;
+  Address: string;
+}
+
+declare const client: TypeSafeDynamoDB<User | Order, "PK", "SK">;
+
+export async function getProfile(userId: String) {
+  const profile = await client
+    .getItem({
+      TableName,
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `#PROFILE#${userId}`,
+        },
+      },
+    })
+    .promise();
+
+  profile.Item?.FullName;
+  // @ts-expect-error - OrderID is only available when SK is prefixed with `#ORDER`
+  profile.Item?.OrderID;
+}
+
+export async function getOrder(userId: string, orderId: string) {
+  const order = await client
+    .getItem({
+      TableName,
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+    })
+    .promise();
+
+  order.Item?.OrderID;
+  // @ts-expect-error - FullName is only available when SK is prefixed with `#PROFILE`
+  order.Item?.FullName;
+}


### PR DESCRIPTION
Closes #6

Adds support for filtering the result of a `getItem` based on the composite key's structure:

Declare an interface for each item in the table and use template-string literals to define the structure of a composite key:

![image](https://user-images.githubusercontent.com/38672686/152664526-129cf38e-5ccb-468f-88b2-52faf137d872.png)

Declare a `TypeSafeDynamoDB` client as normal.

![image](https://user-images.githubusercontent.com/38672686/152664476-e9dc276f-aa7b-438f-8881-01227d11e30a.png)

The composite key's structure is validated by TypeScript:
![image](https://user-images.githubusercontent.com/38672686/152664546-23a1d9c8-54dd-4f2b-a6c5-aa63ac9e2f0b.png)

And the return type is narrowed to the type of item received:
![image](https://user-images.githubusercontent.com/38672686/152664512-d0e2421a-3f9a-449c-86c9-514bd12c47ca.png)

![image](https://user-images.githubusercontent.com/38672686/152664517-ca03df87-3cca-4fec-a4e7-01be296d59c7.png)


