### PR TITLE
feat: add batchGetItem types

### DIFF
--- a/src/batch-get-item-command.ts
+++ b/src/batch-get-item-command.ts
@@ -1,0 +1,59 @@
+import {
+  BatchGetItemCommand as _BatchGetItemCommand,
+  DynamoDBClientResolvedConfig,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import { MetadataBearer } from "@aws-sdk/types";
+import { BatchGetItemInput, BatchGetItemOutput } from "./batch-get-item";
+import { KeyAttribute } from "./key";
+
+export function TypeSafeBatchGetItemCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined
+>(): new <
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+>(
+  input: BatchGetItemInput<
+    Item,
+    Key,
+    PartitionKey,
+    RangeKey,
+    AttributesToGet,
+    ProjectionExpression
+  >
+) => BatchGetItemCommand<
+  Item,
+  Key,
+  PartitionKey,
+  RangeKey,
+  AttributesToGet,
+  ProjectionExpression
+> {
+  return _BatchGetItemCommand as any;
+}
+
+export interface BatchGetItemCommand<
+  Item extends object,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+> extends Command<
+    BatchGetItemInput<
+      Item,
+      Key,
+      PartitionKey,
+      RangeKey,
+      AttributesToGet,
+      ProjectionExpression
+    >,
+    BatchGetItemOutput<Item, Key, AttributesToGet, ProjectionExpression> &
+      MetadataBearer,
+    DynamoDBClientResolvedConfig
+  > {
+  _brand: "BatchGetItemCommand";
+}

--- a/src/batch-get-item.ts
+++ b/src/batch-get-item.ts
@@ -1,16 +1,8 @@
 import type { DynamoDB } from "aws-sdk";
 import { ToAttributeMap } from "./attribute-value";
 import { KeyAttribute, KeyAttributeToObject } from "./key";
+import { Narrow } from "./narrow";
 import { ApplyProjection } from "./projection";
-
-// export interface KeysAndAttributes<
-//   Item extends object,
-//   PartitionKey extends keyof Item,
-//   RangeKey extends keyof Item | undefined,
-//   Key extends KeyAttribute<Item, PartitionKey, RangeKey>
-// > extends Omit<DynamoDB.KeysAndAttributes, "Keys"> {
-//   Keys: Key[];
-// }
 
 export interface BatchGetItemInput<
   Item extends object,
@@ -40,15 +32,12 @@ type ResponseItem<
       ? Extract<Item, KeyAttributeToObject<Item, Key>>
       : Extract<
           ApplyProjection<
-            Extract<Item, KeyAttributeToObject<Item, Key>>,
+            Narrow<Item, Key>,
             Extract<ProjectionExpression, string>
           >,
           object
         >
-    : Pick<
-        Extract<Item, KeyAttributeToObject<Item, Key>>,
-        Extract<AttributesToGet, keyof Item>
-      >
+    : Pick<Narrow<Item, Key>, Extract<AttributesToGet, keyof Item>>
 >;
 
 export interface BatchGetItemOutput<

--- a/src/batch-get-item.ts
+++ b/src/batch-get-item.ts
@@ -1,0 +1,63 @@
+import type { DynamoDB } from "aws-sdk";
+import { KeyAttribute, KeyAttributeToObject } from "./key";
+import { ApplyProjection } from "./projection";
+
+export interface KeysAndAttributes<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>
+> extends Omit<DynamoDB.KeysAndAttributes, "Keys"> {
+  Keys: Key[];
+}
+
+export interface BatchGetItemInput<
+  Item extends object,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+> extends Omit<DynamoDB.BatchGetItemInput, "RequestItems" | "AttributesToGet"> {
+  RequestItems: {
+    [key: string]: KeysAndAttributes<Item, PartitionKey, RangeKey, Key>;
+  };
+  AttributesToGet?: readonly AttributesToGet[] | AttributesToGet[];
+  ProjectionExpression?: ProjectionExpression;
+}
+
+type ResponseItem<
+  Item extends object,
+  Key extends KeyAttribute<Item, any, any>,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+> = undefined extends AttributesToGet
+  ? undefined extends ProjectionExpression
+    ? Extract<Item, KeyAttributeToObject<Item, Key>>
+    : Extract<
+        ApplyProjection<
+          Extract<Item, KeyAttributeToObject<Item, Key>>,
+          Extract<ProjectionExpression, string>
+        >,
+        object
+      >
+  : Pick<
+      Extract<Item, KeyAttributeToObject<Item, Key>>,
+      Extract<AttributesToGet, keyof Item>
+    >;
+
+export interface BatchGetItemOutput<
+  Item extends object,
+  Key extends KeyAttribute<Item, any, any>,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+> extends Omit<DynamoDB.BatchGetItemOutput, "Responses"> {
+  Responses?: {
+    [key: string]: ResponseItem<
+      Item,
+      Key,
+      AttributesToGet,
+      ProjectionExpression
+    >[];
+  };
+}

--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -1,4 +1,5 @@
 import type { AWSError, DynamoDB, Request } from "aws-sdk";
+import { BatchGetItemInput, BatchGetItemOutput } from "./batch-get-item";
 import { Callback } from "./callback";
 import { DeleteItemInput, DeleteItemOutput } from "./delete-item";
 import { GetItemInput, GetItemOutput } from "./get-item";
@@ -10,7 +11,10 @@ export interface TypeSafeDynamoDBv2<
   Item extends object,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined = undefined
-> extends Omit<DynamoDB, "getItem" | "deleteItem" | "putItem" | "query"> {
+> extends Omit<
+    DynamoDB,
+    "getItem" | "deleteItem" | "putItem" | "query" | "batchGetItem"
+  > {
   getItem<
     Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
     AttributesToGet extends keyof Item | undefined = undefined,
@@ -70,4 +74,26 @@ export interface TypeSafeDynamoDBv2<
     >,
     callback?: Callback<QueryOutput<Item, AttributesToGet>, AWSError>
   ): Request<QueryOutput<Item, AttributesToGet>, AWSError>;
+
+  batchGetItem<
+    Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+    AttributesToGet extends keyof Item | undefined = undefined,
+    ProjectionExpression extends string | undefined = undefined
+  >(
+    params: BatchGetItemInput<
+      Item,
+      Key,
+      PartitionKey,
+      RangeKey,
+      AttributesToGet,
+      ProjectionExpression
+    >,
+    callback?: Callback<
+      BatchGetItemOutput<Item, Key, AttributesToGet, ProjectionExpression>,
+      AWSError
+    >
+  ): Request<
+    BatchGetItemOutput<Item, Key, AttributesToGet, ProjectionExpression>,
+    AWSError
+  >;
 }

--- a/src/client-v3.ts
+++ b/src/client-v3.ts
@@ -3,6 +3,7 @@ import type {
   ReturnValue as DynamoDBReturnValue,
 } from "@aws-sdk/client-dynamodb";
 import { MetadataBearer } from "@aws-sdk/types";
+import { BatchGetItemInput, BatchGetItemOutput } from "./batch-get-item";
 import { Callback } from "./callback";
 import { DeleteItemInput, DeleteItemOutput } from "./delete-item";
 import { GetItemInput, GetItemOutput } from "./get-item";
@@ -14,7 +15,10 @@ export interface TypeSafeDynamoDBv3<
   Item extends object,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined = undefined
-> extends Omit<DynamoDB, "getItem" | "deleteItem" | "putItem" | "query"> {
+> extends Omit<
+    DynamoDB,
+    "getItem" | "deleteItem" | "putItem" | "query" | "batchGetItem"
+  > {
   getItem<
     Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
     AttributesToGet extends keyof Item | undefined = undefined,
@@ -126,5 +130,42 @@ export interface TypeSafeDynamoDBv3<
       AttributesToGet
     >,
     callback: Callback<QueryOutput<Item, AttributesToGet> & MetadataBearer, any>
+  ): void;
+
+  batchGetItem<
+    Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+    AttributesToGet extends keyof Item | undefined = undefined,
+    ProjectionExpression extends string | undefined = undefined
+  >(
+    params: BatchGetItemInput<
+      Item,
+      Key,
+      PartitionKey,
+      RangeKey,
+      AttributesToGet,
+      ProjectionExpression
+    >
+  ): Promise<
+    BatchGetItemOutput<Item, Key, AttributesToGet, ProjectionExpression> &
+      MetadataBearer
+  >;
+
+  batchGetItem<
+    Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+    AttributesToGet extends keyof Item | undefined = undefined,
+    ProjectionExpression extends string | undefined = undefined
+  >(
+    params: BatchGetItemInput<
+      Item,
+      Key,
+      PartitionKey,
+      RangeKey,
+      AttributesToGet,
+      ProjectionExpression
+    >,
+    callback: Callback<
+      BatchGetItemOutput<Item, Key, AttributesToGet, ProjectionExpression>,
+      any
+    >
   ): void;
 }

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -219,3 +219,25 @@ export async function getOrder(userId: string, orderId: string) {
   // @ts-expect-error
   order.Item?.FullName;
 }
+
+export async function batchGet(userId: string, orderId: string) {
+  const response = await client
+    .batchGetItem({
+      RequestItems: {
+        MyTable: {
+          Keys: [
+            {
+              PK: { S: `USER#${userId}` },
+              SK: { S: `ORDER#${orderId}` },
+            },
+          ],
+        },
+      },
+      ProjectionExpression: "Username,Status",
+    })
+    .promise();
+
+  response.Responses!.MyTable[0].Username;
+  // @ts-expect-error
+  response.Responses!.MyTable[0].Address;
+}

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -231,9 +231,9 @@ export async function batchGet(userId: string, orderId: string) {
               SK: { S: `ORDER#${orderId}` },
             },
           ],
+          ProjectionExpression: "Username,Status",
         },
       },
-      ProjectionExpression: "Username,Status",
     })
     .promise();
 

--- a/test/v3.test.ts
+++ b/test/v3.test.ts
@@ -1,8 +1,8 @@
-import "jest";
-
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { TypeSafeGetItemCommand } from "../src/get-item-command";
+import "jest";
+import { TypeSafeBatchGetItemCommand } from "../src/batch-get-item-command";
 import { TypeSafeDeleteItemCommand } from "../src/delete-item-command";
+import { TypeSafeGetItemCommand } from "../src/get-item-command";
 import { TypeSafePutItemCommand } from "../src/put-item-command";
 import { TypeSafeQueryCommand } from "../src/query-command";
 
@@ -18,6 +18,11 @@ const PutItemCommand = TypeSafePutItemCommand<MyType>();
 const GetItemCommand = TypeSafeGetItemCommand<MyType, "key", "sort">();
 const DeleteItemCommand = TypeSafeDeleteItemCommand<MyType, "key", "sort">();
 const QueryCommand = TypeSafeQueryCommand<MyType>();
+const BatchGetItemCommand = TypeSafeBatchGetItemCommand<
+  MyType,
+  "key",
+  "sort"
+>();
 
 it("dummy", () => {
   expect(1).toBe(1);
@@ -41,6 +46,20 @@ export async function foo() {
   get.Item?.key;
   // @ts-expect-error
   get.Item?.list;
+
+  const batchGet = await client.send(
+    new BatchGetItemCommand({
+      RequestItems: {
+        TableName: {
+          Keys: [{ key: { S: "" }, sort: { N: "1" } }],
+        },
+      },
+      ProjectionExpression: "sort, list[0]",
+    })
+  );
+  batchGet.Responses!.TableName[0].sort;
+  // @ts-expect-error
+  batchGet.Responses!.TableName[0].list[1];
 
   const put = await client.send(
     new PutItemCommand({

--- a/test/v3.test.ts
+++ b/test/v3.test.ts
@@ -52,9 +52,9 @@ export async function foo() {
       RequestItems: {
         TableName: {
           Keys: [{ key: { S: "" }, sort: { N: "1" } }],
+          ProjectionExpression: "sort, list[0]",
         },
       },
-      ProjectionExpression: "sort, list[0]",
     })
   );
   batchGet.Responses!.TableName[0].sort;


### PR DESCRIPTION
Basic implementation, seems to work. It doesn't quite fit with the spirit of the library though because you can call `batchGetItem` for multiple tables. Should we impose that `TypesafeDynamoDBv{2,3}` only operates on a single table? if so, parameterizing the table name would improve the typing of the response here.

```ts
import { TypeSafeDynamoDBv2 } from "typesafe-dynamodb/lib/client-v2";

const typesafeClient: TypeSafeDynamoDBv2<"MyTableName", Record, "key", "sort"> = client;
const response = await table.batchGetItem({...}).promise();
const responseTable = response.Responses!.MyTableName; // type checks
```