### PR TITLE
feat: add support for updateItem and TypeSafeUpdateItemCommand

### DIFF
--- a/src/client-v2.ts
+++ b/src/client-v2.ts
@@ -5,12 +5,16 @@ import { GetItemInput, GetItemOutput } from "./get-item";
 import { KeyAttribute } from "./key";
 import { PutItemInput, PutItemOutput } from "./put-item";
 import { QueryInput, QueryOutput } from "./query";
+import { UpdateItemInput, UpdateItemOutput } from "./update-item";
 
 export interface TypeSafeDynamoDBv2<
   Item extends object,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined = undefined
-> extends Omit<DynamoDB, "getItem" | "deleteItem" | "putItem" | "query"> {
+> extends Omit<
+    DynamoDB,
+    "getItem" | "deleteItem" | "putItem" | "query" | "updateItem"
+  > {
   getItem<
     Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
     AttributesToGet extends keyof Item | undefined = undefined,
@@ -18,9 +22,9 @@ export interface TypeSafeDynamoDBv2<
   >(
     params: GetItemInput<
       Item,
-      Key,
       PartitionKey,
       RangeKey,
+      Key,
       AttributesToGet,
       ProjectionExpression
     >,
@@ -56,6 +60,30 @@ export interface TypeSafeDynamoDBv2<
     params: PutItemInput<Item, ConditionExpression, ReturnValue>,
     callback?: Callback<PutItemOutput<Item, ReturnValue>, AWSError>
   ): Request<PutItemOutput<Item, ReturnValue>, AWSError>;
+
+  updateItem<
+    Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+    UpdateExpression extends string,
+    ConditionExpression extends string | undefined,
+    ReturnValue extends DynamoDB.ReturnValue = "NONE"
+  >(
+    params: UpdateItemInput<
+      Item,
+      PartitionKey,
+      RangeKey,
+      Key,
+      UpdateExpression,
+      ConditionExpression,
+      ReturnValue
+    >,
+    callback?: Callback<
+      UpdateItemOutput<Item, PartitionKey, RangeKey, Key, ReturnValue>,
+      AWSError
+    >
+  ): Request<
+    UpdateItemOutput<Item, PartitionKey, RangeKey, Key, ReturnValue>,
+    AWSError
+  >;
 
   query<
     KeyConditionExpression extends string | undefined = undefined,

--- a/src/client-v3.ts
+++ b/src/client-v3.ts
@@ -22,9 +22,9 @@ export interface TypeSafeDynamoDBv3<
   >(
     params: GetItemInput<
       Item,
-      Key,
       PartitionKey,
       RangeKey,
+      Key,
       AttributesToGet,
       ProjectionExpression
     >
@@ -40,9 +40,9 @@ export interface TypeSafeDynamoDBv3<
   >(
     params: GetItemInput<
       Item,
-      Key,
       PartitionKey,
       RangeKey,
+      Key,
       AttributesToGet,
       ProjectionExpression
     >,

--- a/src/get-item-command.ts
+++ b/src/get-item-command.ts
@@ -18,17 +18,17 @@ export function TypeSafeGetItemCommand<
 >(
   input: GetItemInput<
     Item,
-    Key,
     PartitionKey,
     RangeKey,
+    Key,
     AttributesToGet,
     ProjectionExpression
   >
 ) => GetItemCommand<
   Item,
-  Key,
   PartitionKey,
   RangeKey,
+  Key,
   AttributesToGet,
   ProjectionExpression
 > {
@@ -37,17 +37,17 @@ export function TypeSafeGetItemCommand<
 
 interface GetItemCommand<
   Item extends object,
-  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
   AttributesToGet extends keyof Item | undefined,
   ProjectionExpression extends string | undefined
 > extends Command<
     GetItemInput<
       Item,
-      Key,
       PartitionKey,
       RangeKey,
+      Key,
       AttributesToGet,
       ProjectionExpression
     >,

--- a/src/get-item.ts
+++ b/src/get-item.ts
@@ -1,13 +1,14 @@
 import type { DynamoDB } from "aws-sdk";
 import { ToAttributeMap } from "./attribute-value";
-import { KeyAttribute, KeyAttributeToObject } from "./key";
+import { KeyAttribute } from "./key";
+import { Narrow } from "./narrow";
 import { ApplyProjection } from "./projection";
 
 export interface GetItemInput<
   Item extends object,
-  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
   AttributesToGet extends keyof Item | undefined,
   ProjectionExpression extends string | undefined
 > extends Omit<
@@ -27,17 +28,14 @@ export interface GetItemOutput<
   Item?: ToAttributeMap<
     undefined extends AttributesToGet
       ? undefined extends ProjectionExpression
-        ? Extract<Item, KeyAttributeToObject<Item, Key>>
+        ? Narrow<Item, Key>
         : Extract<
             ApplyProjection<
-              Extract<Item, KeyAttributeToObject<Item, Key>>,
+              Narrow<Item, Key>,
               Extract<ProjectionExpression, string>
             >,
             object
           >
-      : Pick<
-          Extract<Item, KeyAttributeToObject<Item, Key>>,
-          Extract<AttributesToGet, keyof Item>
-        >
+      : Pick<Narrow<Item, Key>, Extract<AttributesToGet, keyof Item>>
   >;
 }

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -1,0 +1,6 @@
+import { KeyAttribute, KeyAttributeToObject } from "./key";
+
+export type Narrow<
+  Item extends object,
+  Key extends KeyAttribute<Item, any, any>
+> = Extract<Item, KeyAttributeToObject<Item, Key>>;

--- a/src/update-item-command.ts
+++ b/src/update-item-command.ts
@@ -1,0 +1,65 @@
+import {
+  DynamoDBClientResolvedConfig,
+  UpdateItemCommand as _UpdateItemCommand,
+  ReturnValue as DynamoDBReturnValue,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import { UpdateItemInput, UpdateItemOutput } from "./update-item";
+import { MetadataBearer } from "@aws-sdk/types";
+import { KeyAttribute } from "./key";
+
+export interface UpdateItemCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  UpdateExpression extends string,
+  ConditionExpression extends string | undefined,
+  ReturnValue extends DynamoDBReturnValue = "NONE"
+> extends Command<
+    UpdateItemInput<
+      Item,
+      PartitionKey,
+      RangeKey,
+      Key,
+      UpdateExpression,
+      ConditionExpression,
+      ReturnValue
+    >,
+    UpdateItemOutput<Item, PartitionKey, RangeKey, Key, ReturnValue> &
+      MetadataBearer,
+    DynamoDBClientResolvedConfig
+  > {
+  _brand: "UpdateItemCommand";
+}
+
+export function TypeSafeUpdateItemCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined
+>(): new <
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  UpdateExpression extends string,
+  ConditionExpression extends string | undefined = undefined,
+  ReturnValue extends DynamoDBReturnValue = "NONE"
+>(
+  input: UpdateItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    UpdateExpression,
+    ConditionExpression,
+    ReturnValue
+  >
+) => UpdateItemCommand<
+  Item,
+  PartitionKey,
+  RangeKey,
+  Key,
+  UpdateExpression,
+  ConditionExpression,
+  ReturnValue
+> {
+  return _UpdateItemCommand as any;
+}

--- a/src/update-item.ts
+++ b/src/update-item.ts
@@ -1,0 +1,51 @@
+import type { DynamoDB } from "aws-sdk";
+import { ToAttributeMap } from "./attribute-value";
+import {
+  ExpressionAttributeNames,
+  ExpressionAttributeValues,
+} from "./expression-attributes";
+import { KeyAttribute } from "./key";
+import { Narrow } from "./narrow";
+
+export type UpdateItemInput<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  UpdateExpression extends string,
+  ConditionExpression extends string | undefined,
+  ReturnValue extends DynamoDB.ReturnValue = "NONE"
+> = Omit<
+  DynamoDB.UpdateItemInput,
+  | "ConditionExpression"
+  | "UpdateExpression"
+  | "ExpressionAttributeNames"
+  | "ExpressionAttributeValues"
+  | "Item"
+  | "ReturnValues"
+> &
+  ExpressionAttributeNames<ConditionExpression> &
+  ExpressionAttributeValues<ConditionExpression> &
+  ExpressionAttributeNames<UpdateExpression> &
+  ExpressionAttributeValues<UpdateExpression> & {
+    Key: Key;
+    ReturnValues?: ReturnValue;
+    UpdateExpression: UpdateExpression;
+    ConditionExpression?: ConditionExpression;
+  };
+
+export interface UpdateItemOutput<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Key extends KeyAttribute<Item, PartitionKey, RangeKey>,
+  ReturnValue extends DynamoDB.ReturnValue = "NONE"
+> extends Omit<DynamoDB.UpdateItemOutput, "Attributes"> {
+  Attributes?: ReturnValue extends undefined | "NONE"
+    ? undefined
+    : ReturnValue extends "ALL_OLD" | "ALL_NEW"
+    ? Partial<ToAttributeMap<Narrow<Item, Key>>>
+    : ReturnValue extends "UPDATED_OLD" | "UPDATED_NEW"
+    ? Partial<ToAttributeMap<Narrow<Item, Key>>>
+    : Partial<ToAttributeMap<Narrow<Item, Key>>>;
+}

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -352,7 +352,7 @@ export async function updateOrder(userId: string, orderId: string) {
     })
     .promise();
 
-  returnUpdatedOld.Attributes?.OrderID?.S;
+  narrowedType.Attributes?.OrderID?.S;
   // @ts-expect-error - FullName does not exist on order
-  returnUpdatedOld.Attributes?.FullName?.S;
+  narrowedType.Attributes?.FullName?.S;
 }

--- a/test/v2.test.ts
+++ b/test/v2.test.ts
@@ -22,7 +22,7 @@ const table = new DynamoDB() as unknown as TypeSafeDynamoDBv2<
   "sk"
 >;
 
-export async function foo() {
+export async function foo(userId: string) {
   const response = await table
     .query({
       TableName: "TableName",
@@ -53,7 +53,7 @@ export async function foo() {
       TableName: "",
       Key: {
         pk: {
-          S: "",
+          S: `USER#${userId}`,
         },
         sk: {
           S: "",
@@ -68,7 +68,7 @@ export async function foo() {
       TableName: "",
       Key: {
         pk: {
-          S: "",
+          S: `USER#${userId}`,
         },
         sk: {
           S: "",
@@ -218,4 +218,141 @@ export async function getOrder(userId: string, orderId: string) {
   order.Item?.OrderID;
   // @ts-expect-error
   order.Item?.FullName;
+}
+
+export async function updateOrder(userId: string, orderId: string) {
+  const defaultBehavior = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "#k = :v",
+      ExpressionAttributeNames: {
+        "#k": "list",
+      },
+      ExpressionAttributeValues: {
+        ":v": {
+          S: "val",
+        },
+        ":v2": {
+          S: "val2",
+        },
+      },
+      ConditionExpression: "#k = :v2",
+    })
+    .promise();
+  // @ts-expect-error - default ReturnValues is None
+  defaultBehavior.Attributes?.key;
+
+  const returnNone = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "NONE",
+    })
+    .promise();
+  // @ts-expect-error - nothing is Returned
+  returnNone.Attributes.PK.S;
+
+  const returnAllNew = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "ALL_NEW",
+    })
+    .promise();
+  returnAllNew.Attributes?.PK;
+
+  const returnAllOld = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "ALL_OLD",
+    })
+    .promise();
+  returnAllOld.Attributes?.PK?.S;
+
+  const returnUpdatedNew = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "UPDATED_NEW",
+    })
+    .promise();
+  returnUpdatedNew.Attributes?.PK?.S;
+
+  const returnUpdatedOld = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "UPDATED_OLD",
+    })
+    .promise();
+  returnUpdatedOld.Attributes?.PK?.S;
+
+  const narrowedType = await client
+    .updateItem({
+      TableName: "",
+      Key: {
+        PK: {
+          S: `USER#${userId}`,
+        },
+        SK: {
+          S: `ORDER#${orderId}`,
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "UPDATED_OLD",
+    })
+    .promise();
+
+  returnUpdatedOld.Attributes?.OrderID?.S;
+  // @ts-expect-error - FullName does not exist on order
+  returnUpdatedOld.Attributes?.FullName?.S;
 }

--- a/test/v3.test.ts
+++ b/test/v3.test.ts
@@ -5,6 +5,7 @@ import { TypeSafeGetItemCommand } from "../src/get-item-command";
 import { TypeSafeDeleteItemCommand } from "../src/delete-item-command";
 import { TypeSafePutItemCommand } from "../src/put-item-command";
 import { TypeSafeQueryCommand } from "../src/query-command";
+import { TypeSafeUpdateItemCommand } from "../src/update-item-command";
 
 interface MyType {
   key: string;
@@ -15,6 +16,7 @@ interface MyType {
 const client = new DynamoDBClient({});
 
 const PutItemCommand = TypeSafePutItemCommand<MyType>();
+const UpdateItemCommand = TypeSafeUpdateItemCommand<MyType, "key", "sort">();
 const GetItemCommand = TypeSafeGetItemCommand<MyType, "key", "sort">();
 const DeleteItemCommand = TypeSafeDeleteItemCommand<MyType, "key", "sort">();
 const QueryCommand = TypeSafeQueryCommand<MyType>();
@@ -92,4 +94,121 @@ export async function foo() {
     })
   );
   query.Items?.[0].key;
+}
+
+export async function updateItem() {
+  const defaultBehavior = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "#k = :v",
+      ExpressionAttributeNames: {
+        "#k": "list",
+      },
+      ExpressionAttributeValues: {
+        ":v": {
+          S: "val",
+        },
+        ":v2": {
+          S: "val2",
+        },
+      },
+      ConditionExpression: "#k = :v2",
+    })
+  );
+  // @ts-expect-error - default ReturnValues is None
+  defaultBehavior.Attributes?.key;
+
+  const returnNone = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "NONE",
+    })
+  );
+  // @ts-expect-error - nothing is Returned
+  returnNone.Attributes?.key;
+
+  const returnAllNew = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "ALL_NEW",
+    })
+  );
+  returnAllNew.Attributes?.key?.S;
+
+  const returnAllOld = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "ALL_OLD",
+    })
+  );
+  returnAllOld.Attributes?.key?.S;
+
+  const returnUpdatedNew = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "UPDATED_NEW",
+    })
+  );
+  returnUpdatedNew.Attributes?.key?.S;
+
+  const returnUpdatedOld = await client.send(
+    new UpdateItemCommand({
+      TableName: "",
+      Key: {
+        key: {
+          S: "",
+        },
+        sort: {
+          N: "1",
+        },
+      },
+      UpdateExpression: "a = 1",
+      ReturnValues: "UPDATED_OLD",
+    })
+  );
+  returnUpdatedOld.Attributes?.key?.S;
 }


### PR DESCRIPTION
Fixes #20 

Adds support for `updateItem` and `TypeSafeUpdateItemCommand`.

To create a typesafe command:
```ts
const UpdateItemCommand = TypeSafeUpdateItemCommand<MyType, "key", "sort">();
```

If you specify `ReturnValues` to `ALL_OLD`, `ALL_NEW`, `UPDATED_NEW` or `UPDATED_OLD`, then the typings narrow the return type of `Attributes` to items of the Union type that are compatible with the `Key`.
```ts
const narrowedType = await client
  .send(new MyUpdateCommand{
    TableName: "",
    Key: {
      PK: {
        S: `USER#${userId}`,
      },
      SK: {
        S: `ORDER#${orderId}`,
      },
    },
    UpdateExpression: "a = 1",
    ReturnValues: "UPDATED_OLD",
  });

narrowedType.Attributes?.OrderID?.S;
// @ts-expect-error - FullName does not exist on order
narrowedType.Attributes?.FullName?.S;
```

`ExpressionAttributeNames` and `ExpressionAttributeValues` are validated against the `ConditionExpression` and `UpdateExpression`:
```ts
await client
  .send(new MyUpdateCommand({
    TableName: "",
    Key: {
      PK: {
        S: `USER#${userId}`,
      },
      SK: {
        S: `ORDER#${orderId}`,
      },
    },
    UpdateExpression: "#k = :v",
    ExpressionAttributeNames: {
      "#k": "list",
    },
    ExpressionAttributeValues: {
      ":v": {
        S: "val",
      },
      ":v2": {
        S: "val2",
      },
    },
    ConditionExpression: "#k = :v2",
  });
```