### PR TITLE
fix: support expression attrbitube names in projection expressions.

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -22,6 +22,7 @@ export type QueryInput<
 > &
   ExpressionAttributeNames<KeyConditionExpression> &
   ExpressionAttributeNames<FilterExpression> &
+  ExpressionAttributeNames<ProjectionExpression> &
   ExpressionAttributeValues<KeyConditionExpression, Format> &
   ExpressionAttributeValues<FilterExpression, Format> & {
     KeyConditionExpression?: KeyConditionExpression;

--- a/test/v2-document.test.ts
+++ b/test/v2-document.test.ts
@@ -40,6 +40,24 @@ export async function foo(userId: string) {
     })
     .promise();
 
+  // using only projection
+  await table
+    .query({
+      TableName: "TableName",
+      AttributesToGet: ["attr"],
+      KeyConditionExpression: "key = :val",
+      FilterExpression: "key2 = :val2",
+      ProjectionExpression: "#key1",
+      ExpressionAttributeNames: {
+        "#key1": "",
+      },
+      ExpressionAttributeValues: {
+        ":val": "val",
+        ":val2": true,
+      },
+    })
+    .promise();
+
   if (response.Items) {
     response.Items[0].attr;
   }


### PR DESCRIPTION
Closes #9

When expression attribute names where only used in ProjectionExpressions, the compiler would complain. Support and enforce correct use of attribute names when using projection.

```ts
  await table
    .query({
      TableName: "TableName",
      AttributesToGet: ["attr"],
      KeyConditionExpression: "key = :val",
      FilterExpression: "key2 = :val2",
      ProjectionExpression: "#key1",
      ExpressionAttributeNames: { // <-- would not allow this, now it does
        "#key1": "",
      },
      ExpressionAttributeValues: {
        ":val": "val",
        ":val2": true,
      },
    })
    .promise();
```