### PR TITLE
fix: use correct document array type

### DIFF
--- a/src/attribute-value.ts
+++ b/src/attribute-value.ts
@@ -32,7 +32,7 @@ export type DocumentValue =
   | boolean
   | number
   | string
-  | Document[]
+  | DocumentValue[]
   | NativeBinaryAttribute
   | {
       [key: string]: DocumentValue;


### PR DESCRIPTION
`Document` seems to be a typescript built-in in `dom`. This is causing libraries without `dom` to fail. Also, probably not what you want.