### PR TITLE
fix: support long UpdateExpressions

### DIFF
--- a/src/expression-attributes.ts
+++ b/src/expression-attributes.ts
@@ -29,14 +29,26 @@ export type ExpressionAttributeNames<Expression extends string | undefined> =
       };
 
 type ParseConditionExpressionNames<Str extends string | undefined> = Extract<
-  ParsePrefixedString<"#", Str>,
+  ParsePrefixedString<"#", Split<Str>>,
   string
 >;
 
 type ParseConditionExpressionValues<Str extends string | undefined> = Extract<
-  ParsePrefixedString<":", Str>,
+  ParsePrefixedString<":", Split<Str>>,
   string
 >;
+
+// long expressions can easily reach the 50 depth limit
+// to work around this, Split will partition the string by the `,` delimiter.
+// the reason for `,` is because update expressions are separated by `,`
+// This means that we can support strings longer than 50.
+// The 50 max depth limit now only applies to the length of strings between commas, `,`.
+type Split<S extends string | undefined> =
+  S extends `${infer pre},${infer post}`
+    ? pre | Split<post>
+    : S extends undefined
+    ? ""
+    : S;
 
 type ParsePrefixedString<
   Prefix extends string,

--- a/src/expression-attributes.ts
+++ b/src/expression-attributes.ts
@@ -43,6 +43,7 @@ type ParseConditionExpressionValues<Str extends string | undefined> = Extract<
 // the reason for `,` is because update expressions are separated by `,`
 // This means that we can support strings longer than 50.
 // The 50 max depth limit now only applies to the length of strings between commas, `,`.
+// @see https://github.com/sam-goodwin/typesafe-dynamodb/issues/29
 type Split<S extends string | undefined> =
   S extends `${infer pre},${infer post}`
     ? pre | Split<post>

--- a/test/expression-attributes.test.ts
+++ b/test/expression-attributes.test.ts
@@ -1,0 +1,66 @@
+import "jest";
+
+import * as AWS from "aws-sdk";
+import { TypeSafeDocumentClientV2 } from "../src/document-client-v2";
+
+export interface Order<
+  UserID extends string = string,
+  OrderID extends string = string
+> {
+  PK: `USER#${UserID}`;
+  SK: `ORDER#${OrderID}`;
+  userId: string;
+  orderId: string;
+}
+
+test("long UpdateExpression should compile", () => {
+  const client: TypeSafeDocumentClientV2<Order, "PK", "SK"> =
+    new AWS.DynamoDB.DocumentClient() as any;
+
+  const userId = "userId";
+  const orderId = "orderId";
+
+  () => {
+    client
+      .update({
+        TableName: "",
+        Key: {
+          PK: `USER#${userId}`,
+          SK: `ORDER#${orderId}`,
+        },
+        UpdateExpression: `SET MyMapName.myLongFieldNameA = :myLongFieldValueA, 
+                             MyMapName.myLongFieldNameB = :myLongFieldValueB,
+                             MyMapName.myLongFieldNameC = :myLongFieldValueC,
+                             MyMapName.myLongFieldNameD = :myLongFieldValueD,
+                             MyMapName.myLongFieldNameE = :myLongFieldValueE,
+                             MyMapName.myLongFieldNameF = :myLongFieldValueF,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueG,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueH,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueI,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueJ,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueK,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueL,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueM,
+                             MyMapName.myLongFieldNameG = :myLongFieldValueN,
+                          `,
+        ExpressionAttributeValues: {
+          ":myLongFieldValueA": 1,
+          ":myLongFieldValueB": 1,
+          ":myLongFieldValueC": 1,
+          ":myLongFieldValueD": 1,
+          ":myLongFieldValueE": 1,
+          ":myLongFieldValueF": 1,
+          ":myLongFieldValueG": 1,
+          ":myLongFieldValueH": 1,
+          ":myLongFieldValueI": 1,
+          ":myLongFieldValueJ": 1,
+          ":myLongFieldValueK": 1,
+          ":myLongFieldValueL": 1,
+          ":myLongFieldValueM": 1,
+          ":myLongFieldValueN": 1,
+        },
+        ReturnValues: "NONE",
+      })
+      .promise();
+  };
+});


### PR DESCRIPTION
Fixes #29 

The `ParseConditionExpressionNames` and `ParseConditionExpressionValues` were hitting the max-depth 50 limit for TypeScript recursion. To work around this, we will now split the expression by the `,` delimiter. The 50-depth limit now only applies to the length of a single update expression:

```
name1 = value1, name2 = value2, ..., nameN = valueN 
```

Before, the depth was reached when this string reached 50 characters.

Now, the depth limit will only be reached if a single expression exceeds 50 characters, or the number of expressions exceeds 50.