### PR TITLE
fix: add missing MetadataBearer types to v3 Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ jspm_packages/
 .yarn-integrity
 .cache
 .DS_Store
+.dccache
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -20,7 +20,7 @@ const project = new typescript.TypeScriptProject({
       lib: ["dom"],
     },
   },
-  gitignore: [".DS_Store"],
+  gitignore: [".DS_Store", ".dccache"],
   releaseToNpm: true,
 });
 

--- a/src/client-v3.ts
+++ b/src/client-v3.ts
@@ -82,7 +82,8 @@ export interface TypeSafeDynamoDBv3<
         AttributesToGet,
         ProjectionExpression,
         JsonFormat.AttributeValue
-      >,
+      > &
+        MetadataBearer,
       any
     >
   ): void;
@@ -197,7 +198,8 @@ export interface TypeSafeDynamoDBv3<
       Key,
       ReturnValue,
       JsonFormat.AttributeValue
-    >
+    > &
+      MetadataBearer
   >;
 
   updateItem<
@@ -229,7 +231,8 @@ export interface TypeSafeDynamoDBv3<
         Key,
         ReturnValue,
         JsonFormat.AttributeValue
-      >,
+      > &
+        MetadataBearer,
       any
     >
   ): void;
@@ -285,7 +288,10 @@ export interface TypeSafeDynamoDBv3<
       AttributesToGet,
       JsonFormat.Document
     >
-  ): Promise<ScanOutput<Item, AttributesToGet, JsonFormat.AttributeValue>>;
+  ): Promise<
+    ScanOutput<Item, AttributesToGet, JsonFormat.AttributeValue> &
+      MetadataBearer
+  >;
 
   scan<
     FilterExpression extends string | undefined = undefined,

--- a/src/document-client-v3.ts
+++ b/src/document-client-v3.ts
@@ -167,7 +167,8 @@ export interface TypeSafeDocumentClientV3<
       Key,
       ReturnValue,
       JsonFormat.Document
-    >
+    > &
+      MetadataBearer
   >;
 
   update<
@@ -194,7 +195,8 @@ export interface TypeSafeDocumentClientV3<
         Key,
         ReturnValue,
         JsonFormat.Document
-      >,
+      > &
+        MetadataBearer,
       any
     >
   ): void;


### PR DESCRIPTION
Fixes #31 

The AWS SDK V3's MetadataBearer type was missing from many return types in the V3 client and document clients.