### PR TITLE
fix: UpdateItemOutput's Attributes shouldn't be partial if ReturnValue is set to ALL_*

### DIFF
--- a/src/update-item.ts
+++ b/src/update-item.ts
@@ -47,7 +47,7 @@ export interface UpdateItemOutput<
     ReturnValue extends undefined | "NONE"
       ? undefined
       : ReturnValue extends "ALL_OLD" | "ALL_NEW"
-      ? Partial<Narrow<Item, Key, Format>>
+      ? Narrow<Item, Key, Format>
       : ReturnValue extends "UPDATED_OLD" | "UPDATED_NEW"
       ? Partial<Narrow<Item, Key, Format>>
       : Partial<Narrow<Item, Key, Format>>,


### PR DESCRIPTION
I'm guessing this is just a copy/paste error. I checked out `delete-item.ts` and `update-item.ts` and they both look as expected (partials only with `UPDATED_{NEW, OLD}`).

[Relevant aws docs section](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html):

> ALL_NEW - Returns all of the attributes of the item, as they appear after the UpdateItem operation.
> UPDATED_NEW - Returns only the updated attributes, as they appear after the UpdateItem operation.

This lib is great btw, thanks for sharing it.