### PR TITLE
fix: add specific commands for V3's DocumentClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Both the AWS SDK v2 and v3 provide a javascript-friendly interface called the `D
 
 #### AWS SDK V2
 
-For the SDK V2 client, cast it to `TypeSafeDynamoDBv2`.
+For the SDK V2 client, cast it to `TypeSafeDocumentClientV2`.
 
 See: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html
 
@@ -115,25 +115,28 @@ const table = new DynamoDB.DocumentClient() as TypeSafeDocumentClientV2<
 
 #### AWS SDK V3
 
-When defining your Command types, specify the `JsonFormat.Document` type parameter to adapt it to the `DocumentClient` interface.
+When defining your Command types, use the corresponding `TypeSafe*DocumentCommand` type, for example `TypeSafeGetDocumentCommand` instead of `TypeSafeGetItemCommand`:
+
+- GetItem - `TypeSafeGetDocumentCommand`
+- PutItem - `TypeSafePutDocumentCommand`
+- DeleteItem - `TypeSafeDeleteDocumentCommand`
+- UpdateItem - `TypeSafeUpdateDocumentCommand`
+- Query - `TypeSafeQueryDocumentCommand`
+- Scan - `TypeSafeScanDocumentCommand`
 
 See: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_lib_dynamodb.html
 
 ```ts
 import { JsonFormat } from "typesafe-dynamodb";
-import { TypeSafeGetItemCommand } from "typesafe-dynamodb/lib/get-item-command";
+import { TypeSafeGetDocumentCommand } from "typesafe-dynamodb/lib/get-document-command";
 
-const GetItemCommand = TypeSafeGetItemCommand<
-  MyType,
-  "key",
-  "sort",
-  JsonFormat.Document // specify the format as Document.
->();
+const MyGetItemCommand = TypeSafeGetDocumentCommand<MyType, "key", "sort">();
 ```
 
 For the SDK V3 client, cast it to `TypeSafeDynamoDBv3`.
 
 ```ts
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { TypeSafeDocumentClientV3 } from "typesafe-dynamodb/lib/document-client-v3";
 
@@ -142,6 +145,14 @@ const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(
   client
 ) as TypeSafeDocumentClientV3<MyType, "key", "sort">;
+```
+
+And then call `.send` with an instance of your TypeSafe Command:
+
+```ts
+docClient.send(new MyGetItemCommand({
+  ..
+}));
 ```
 
 ## Features

--- a/src/delete-document-command.ts
+++ b/src/delete-document-command.ts
@@ -1,0 +1,11 @@
+import { DeleteCommand as _DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import type { DeleteCommand } from "./delete-item";
+import type { JsonFormat } from "./json-format";
+
+export function TypeSafeDeleteDocumentCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined
+>(): DeleteCommand<Item, PartitionKey, RangeKey, JsonFormat.Document> {
+  return _DeleteCommand as any;
+}

--- a/src/delete-item-command.ts
+++ b/src/delete-item-command.ts
@@ -1,65 +1,11 @@
-import {
-  DynamoDBClientResolvedConfig,
-  DeleteItemCommand as _DeleteItemCommand,
-  ReturnValue as DynamoDBReturnValue,
-} from "@aws-sdk/client-dynamodb";
-import type { Command } from "@aws-sdk/smithy-client";
-import { DeleteItemInput, DeleteItemOutput } from "./delete-item";
-import { MetadataBearer } from "@aws-sdk/types";
-import { TableKey } from "./key";
-import { JsonFormat } from "./json-format";
-
-export interface DeleteItemCommand<
-  Item extends object,
-  PartitionKey extends keyof Item,
-  RangeKey extends keyof Item | undefined,
-  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
-  ConditionExpression extends string | undefined,
-  ReturnValue extends DynamoDBReturnValue,
-  Format extends JsonFormat
-> extends Command<
-    DeleteItemInput<
-      Item,
-      PartitionKey,
-      RangeKey,
-      Key,
-      ConditionExpression,
-      ReturnValue,
-      Format
-    >,
-    DeleteItemOutput<Item, ReturnValue, Format> & MetadataBearer,
-    DynamoDBClientResolvedConfig
-  > {
-  _brand: "DeleteItemCommand";
-}
+import { DeleteItemCommand as _DeleteItemCommand } from "@aws-sdk/client-dynamodb";
+import type { DeleteCommand } from "./delete-item";
+import type { JsonFormat } from "./json-format";
 
 export function TypeSafeDeleteItemCommand<
   Item extends object,
   PartitionKey extends keyof Item,
-  RangeKey extends keyof Item | undefined,
-  Format extends JsonFormat = JsonFormat.Default
->(): new <
-  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
-  ConditionExpression extends string | undefined = undefined,
-  ReturnValue extends DynamoDBReturnValue = "NONE"
->(
-  input: DeleteItemInput<
-    Item,
-    PartitionKey,
-    RangeKey,
-    Key,
-    ConditionExpression,
-    ReturnValue,
-    Format
-  >
-) => DeleteItemCommand<
-  Item,
-  PartitionKey,
-  RangeKey,
-  Key,
-  ConditionExpression,
-  ReturnValue,
-  Format
-> {
+  RangeKey extends keyof Item | undefined
+>(): DeleteCommand<Item, PartitionKey, RangeKey, JsonFormat.AttributeValue> {
   return _DeleteItemCommand as any;
 }

--- a/src/delete-item.ts
+++ b/src/delete-item.ts
@@ -1,10 +1,16 @@
 import type { DynamoDB } from "aws-sdk";
-import {
+import type {
   ExpressionAttributeNames,
   ExpressionAttributeValues,
 } from "./expression-attributes";
-import { FormatObject, JsonFormat } from "./json-format";
-import { TableKey } from "./key";
+import type { FormatObject, JsonFormat } from "./json-format";
+import type { TableKey } from "./key";
+import type {
+  DynamoDBClientResolvedConfig,
+  ReturnValue as DynamoDBReturnValue,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import type { MetadataBearer } from "@aws-sdk/types";
 
 export type DeleteItemInput<
   Item extends object,
@@ -43,3 +49,38 @@ export interface DeleteItemOutput<
     ? Partial<FormatObject<Item, Format>>
     : Partial<FormatObject<Item, Format>>;
 }
+
+export type DeleteCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Format extends JsonFormat
+> = new <
+  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
+  ConditionExpression extends string | undefined = undefined,
+  ReturnValue extends DynamoDBReturnValue = "NONE"
+>(
+  input: DeleteItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    ConditionExpression,
+    ReturnValue,
+    Format
+  >
+) => Command<
+  DeleteItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    ConditionExpression,
+    ReturnValue,
+    Format
+  >,
+  DeleteItemOutput<Item, ReturnValue, Format> & MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "DeleteItemCommand";
+};

--- a/src/get-command.ts
+++ b/src/get-command.ts
@@ -1,0 +1,53 @@
+import {
+  DynamoDBClientResolvedConfig,
+  GetItemCommand as _GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import { TableKey } from "./key";
+import { GetItemInput, GetItemOutput } from "./get-item";
+import { MetadataBearer } from "@aws-sdk/types";
+import { JsonFormat } from "./json-format";
+
+export type GetCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Format extends JsonFormat
+> = new <
+  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
+  AttributesToGet extends keyof Item | undefined,
+  ProjectionExpression extends string | undefined
+>(
+  input: GetItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    AttributesToGet,
+    ProjectionExpression,
+    Format
+  >
+) => Command<
+  GetItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    AttributesToGet,
+    ProjectionExpression,
+    Format
+  >,
+  GetItemOutput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    AttributesToGet,
+    ProjectionExpression,
+    Format
+  > &
+    MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "GetItemCommand";
+};

--- a/src/get-document-command.ts
+++ b/src/get-document-command.ts
@@ -2,10 +2,10 @@ import { GetCommand as _GetCommand } from "@aws-sdk/lib-dynamodb";
 import type { JsonFormat } from "./json-format";
 import type { GetCommand } from "./get-command";
 
-export function TypeSafeGetItemCommand<
+export function TypeSafeGetDocumentCommand<
   Item extends object,
   PartitionKey extends keyof Item,
   RangeKey extends keyof Item | undefined
->(): GetCommand<Item, PartitionKey, RangeKey, JsonFormat.AttributeValue> {
+>(): GetCommand<Item, PartitionKey, RangeKey, JsonFormat.Document> {
   return _GetCommand as any;
 }

--- a/src/put-document-command.ts
+++ b/src/put-document-command.ts
@@ -1,0 +1,10 @@
+import { PutCommand as _PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { JsonFormat } from "./json-format";
+import type { PutCommand } from "./put-item";
+
+export function TypeSafePutDocumentCommand<Item extends object>(): PutCommand<
+  Item,
+  JsonFormat.Document
+> {
+  return _PutCommand as any;
+}

--- a/src/put-item-command.ts
+++ b/src/put-item-command.ts
@@ -1,34 +1,10 @@
-import {
-  DynamoDBClientResolvedConfig,
-  PutItemCommand as _PutItemCommand,
-  ReturnValue as DynamoDBReturnValue,
-} from "@aws-sdk/client-dynamodb";
-import type { Command } from "@aws-sdk/smithy-client";
-import { PutItemInput, PutItemOutput } from "./put-item";
-import { MetadataBearer } from "@aws-sdk/types";
-import { JsonFormat } from "./json-format";
+import { PutItemCommand as _PutItemCommand } from "@aws-sdk/client-dynamodb";
+import type { JsonFormat } from "./json-format";
+import type { PutCommand } from "./put-item";
 
-export interface PutItemCommand<
-  Item extends object,
-  ConditionExpression extends string | undefined,
-  ReturnValue extends DynamoDBReturnValue,
-  Format extends JsonFormat
-> extends Command<
-    PutItemInput<Item, ConditionExpression, ReturnValue, Format>,
-    PutItemOutput<Item, ReturnValue, Format> & MetadataBearer,
-    DynamoDBClientResolvedConfig
-  > {
-  _brand: "PutItemCommand";
-}
-
-export function TypeSafePutItemCommand<
-  Item extends object,
-  Format extends JsonFormat = JsonFormat.Default
->(): new <
-  ConditionExpression extends string | undefined = undefined,
-  ReturnValue extends DynamoDBReturnValue = "NONE"
->(
-  input: PutItemInput<Item, ConditionExpression, ReturnValue, Format>
-) => PutItemCommand<Item, ConditionExpression, ReturnValue, Format> {
+export function TypeSafePutItemCommand<Item extends object>(): PutCommand<
+  Item,
+  JsonFormat.AttributeValue
+> {
   return _PutItemCommand as any;
 }

--- a/src/put-item.ts
+++ b/src/put-item.ts
@@ -1,9 +1,15 @@
 import type { DynamoDB } from "aws-sdk";
-import {
+import type {
   ExpressionAttributeNames,
   ExpressionAttributeValues,
 } from "./expression-attributes";
-import { FormatObject, JsonFormat } from "./json-format";
+import type { FormatObject, JsonFormat } from "./json-format";
+import type {
+  DynamoDBClientResolvedConfig,
+  ReturnValue as DynamoDBReturnValue,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import type { MetadataBearer } from "@aws-sdk/types";
 
 export type PutItemInput<
   Item extends object,
@@ -38,3 +44,16 @@ export interface PutItemOutput<
     ? Partial<FormatObject<Item, Format>>
     : Partial<FormatObject<Item, Format>>;
 }
+
+export type PutCommand<Item extends object, Format extends JsonFormat> = new <
+  ConditionExpression extends string | undefined = undefined,
+  ReturnValue extends DynamoDBReturnValue = "NONE"
+>(
+  input: PutItemInput<Item, ConditionExpression, ReturnValue, Format>
+) => Command<
+  PutItemInput<Item, ConditionExpression, ReturnValue, Format>,
+  PutItemOutput<Item, ReturnValue, Format> & MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "PutItemCommand";
+};

--- a/src/query-command.ts
+++ b/src/query-command.ts
@@ -1,42 +1,10 @@
-import {
-  DynamoDBClientResolvedConfig,
-  QueryCommand as _QueryCommand,
-} from "@aws-sdk/client-dynamodb";
-import type { Command } from "@aws-sdk/smithy-client";
-import { QueryInput, QueryOutput } from "./query";
-import { MetadataBearer } from "@aws-sdk/types";
+import { QueryCommand as _QueryCommand } from "@aws-sdk/client-dynamodb";
+import { QueryCommand } from "./query";
 import { JsonFormat } from "./json-format";
 
-export function TypeSafeQueryCommand<
-  Item extends object,
-  Format extends JsonFormat = JsonFormat.Default
->(): new <
-  KeyConditionExpression extends string | undefined,
-  FilterExpression extends string | undefined,
-  ProjectionExpression extends string | undefined,
-  AttributesToGet extends keyof Item | undefined
->(
-  input: QueryInput<
-    Item,
-    KeyConditionExpression,
-    FilterExpression,
-    ProjectionExpression,
-    AttributesToGet,
-    Format
-  >
-) => Command<
-  QueryInput<
-    Item,
-    KeyConditionExpression,
-    FilterExpression,
-    ProjectionExpression,
-    AttributesToGet,
-    Format
-  >,
-  QueryOutput<Item, AttributesToGet, Format> & MetadataBearer,
-  DynamoDBClientResolvedConfig
-> & {
-  _brand: "QueryCommand";
-} {
+export function TypeSafeQueryCommand<Item extends object>(): QueryCommand<
+  Item,
+  JsonFormat.AttributeValue
+> {
   return _QueryCommand as any;
 }

--- a/src/query-document-command.ts
+++ b/src/query-document-command.ts
@@ -1,0 +1,9 @@
+import { QueryCommand as _QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type { JsonFormat } from "./json-format";
+import type { QueryCommand } from "./query";
+
+export function TypeSafeQueryDocumentCommand<
+  Item extends object
+>(): QueryCommand<Item, JsonFormat.Document> {
+  return _QueryCommand as any;
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,9 +1,12 @@
+import type { DynamoDBClientResolvedConfig } from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import type { MetadataBearer } from "@aws-sdk/types";
 import type { DynamoDB } from "aws-sdk";
-import {
+import type {
   ExpressionAttributeNames,
   ExpressionAttributeValues,
 } from "./expression-attributes";
-import { FormatObject, JsonFormat } from "./json-format";
+import type { FormatObject, JsonFormat } from "./json-format";
 
 export type QueryInput<
   Item extends object,
@@ -43,3 +46,32 @@ export interface QueryOutput<
     Format
   >[];
 }
+
+export type QueryCommand<Item extends object, Format extends JsonFormat> = new <
+  KeyConditionExpression extends string | undefined,
+  FilterExpression extends string | undefined,
+  ProjectionExpression extends string | undefined,
+  AttributesToGet extends keyof Item | undefined
+>(
+  input: QueryInput<
+    Item,
+    KeyConditionExpression,
+    FilterExpression,
+    ProjectionExpression,
+    AttributesToGet,
+    Format
+  >
+) => Command<
+  QueryInput<
+    Item,
+    KeyConditionExpression,
+    FilterExpression,
+    ProjectionExpression,
+    AttributesToGet,
+    Format
+  >,
+  QueryOutput<Item, AttributesToGet, Format> & MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "QueryCommand";
+};

--- a/src/scan-command.ts
+++ b/src/scan-command.ts
@@ -1,0 +1,10 @@
+import { ScanCommand as _ScanCommand } from "@aws-sdk/client-dynamodb";
+import type { ScanCommand } from "./scan";
+import type { JsonFormat } from "./json-format";
+
+export function TypeSafeScanCommand<Item extends object>(): ScanCommand<
+  Item,
+  JsonFormat.AttributeValue
+> {
+  return _ScanCommand as any;
+}

--- a/src/scan-document-command.ts
+++ b/src/scan-document-command.ts
@@ -1,0 +1,10 @@
+import { ScanCommand as _ScanCommand } from "@aws-sdk/client-dynamodb";
+import type { JsonFormat } from "./json-format";
+import type { ScanCommand } from "./scan";
+
+export function TypeSafeScanDocumentCommand<Item extends object>(): ScanCommand<
+  Item,
+  JsonFormat.Document
+> {
+  return _ScanCommand as any;
+}

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,9 +1,15 @@
 import type { DynamoDB } from "aws-sdk";
-import {
+import type {
   ExpressionAttributeNames,
   ExpressionAttributeValues,
 } from "./expression-attributes";
-import { FormatObject, JsonFormat } from "./json-format";
+import type { FormatObject, JsonFormat } from "./json-format";
+import type {
+  DynamoDBClientResolvedConfig,
+  ScanCommand as _ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { Command } from "@aws-sdk/smithy-client";
+import type { MetadataBearer } from "@aws-sdk/types";
 
 export type ScanInput<
   Item extends object,
@@ -37,3 +43,29 @@ export interface ScanOutput<
     Format
   >[];
 }
+
+export type ScanCommand<Item extends object, Format extends JsonFormat> = new <
+  FilterExpression extends string | undefined,
+  ProjectionExpression extends string | undefined,
+  AttributesToGet extends keyof Item | undefined
+>(
+  input: ScanInput<
+    Item,
+    FilterExpression,
+    ProjectionExpression,
+    AttributesToGet,
+    Format
+  >
+) => Command<
+  ScanInput<
+    Item,
+    FilterExpression,
+    ProjectionExpression,
+    AttributesToGet,
+    Format
+  >,
+  ScanOutput<Item, AttributesToGet, Format> & MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "ScanCommand";
+};

--- a/src/update-document-command.ts
+++ b/src/update-document-command.ts
@@ -1,0 +1,11 @@
+import { UpdateCommand as _UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import type { UpdateCommand } from "./update-item";
+import type { JsonFormat } from "./json-format";
+
+export function TypeSafeUpdateDocumentCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined
+>(): UpdateCommand<Item, PartitionKey, RangeKey, JsonFormat.Document> {
+  return _UpdateCommand as any;
+}

--- a/src/update-item-command.ts
+++ b/src/update-item-command.ts
@@ -1,71 +1,11 @@
-import {
-  DynamoDBClientResolvedConfig,
-  UpdateItemCommand as _UpdateItemCommand,
-  ReturnValue as DynamoDBReturnValue,
-} from "@aws-sdk/client-dynamodb";
-import type { Command } from "@aws-sdk/smithy-client";
-import { UpdateItemInput, UpdateItemOutput } from "./update-item";
-import { MetadataBearer } from "@aws-sdk/types";
-import { TableKey } from "./key";
+import { UpdateItemCommand as _UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+import { UpdateCommand } from "./update-item";
 import { JsonFormat } from "./json-format";
-
-export interface UpdateItemCommand<
-  Item extends object,
-  PartitionKey extends keyof Item,
-  RangeKey extends keyof Item | undefined,
-  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
-  UpdateExpression extends string,
-  ConditionExpression extends string | undefined,
-  ReturnValue extends DynamoDBReturnValue = "NONE",
-  Format extends JsonFormat = JsonFormat.Default
-> extends Command<
-    UpdateItemInput<
-      Item,
-      PartitionKey,
-      RangeKey,
-      Key,
-      UpdateExpression,
-      ConditionExpression,
-      ReturnValue,
-      Format
-    >,
-    UpdateItemOutput<Item, PartitionKey, RangeKey, Key, ReturnValue, Format> &
-      MetadataBearer,
-    DynamoDBClientResolvedConfig
-  > {
-  _brand: "UpdateItemCommand";
-}
 
 export function TypeSafeUpdateItemCommand<
   Item extends object,
   PartitionKey extends keyof Item,
-  RangeKey extends keyof Item | undefined,
-  Format extends JsonFormat = JsonFormat.Default
->(): new <
-  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
-  UpdateExpression extends string,
-  ConditionExpression extends string | undefined = undefined,
-  ReturnValue extends DynamoDBReturnValue = "NONE"
->(
-  input: UpdateItemInput<
-    Item,
-    PartitionKey,
-    RangeKey,
-    Key,
-    UpdateExpression,
-    ConditionExpression,
-    ReturnValue,
-    Format
-  >
-) => UpdateItemCommand<
-  Item,
-  PartitionKey,
-  RangeKey,
-  Key,
-  UpdateExpression,
-  ConditionExpression,
-  ReturnValue,
-  Format
-> {
+  RangeKey extends keyof Item | undefined
+>(): UpdateCommand<Item, PartitionKey, RangeKey, JsonFormat.AttributeValue> {
   return _UpdateItemCommand as any;
 }

--- a/src/update-item.ts
+++ b/src/update-item.ts
@@ -1,11 +1,17 @@
 import type { DynamoDB } from "aws-sdk";
-import {
+import type {
   ExpressionAttributeNames,
   ExpressionAttributeValues,
 } from "./expression-attributes";
-import { FormatObject, JsonFormat } from "./json-format";
-import { TableKey } from "./key";
-import { Narrow } from "./narrow";
+import type { FormatObject, JsonFormat } from "./json-format";
+import type { TableKey } from "./key";
+import type { Narrow } from "./narrow";
+import type {
+  DynamoDBClientResolvedConfig,
+  ReturnValue as DynamoDBReturnValue,
+} from "@aws-sdk/client-dynamodb";
+import type { MetadataBearer } from "@aws-sdk/types";
+import type { Command } from "@aws-sdk/smithy-client";
 
 export type UpdateItemInput<
   Item extends object,
@@ -54,3 +60,42 @@ export interface UpdateItemOutput<
     Format
   >;
 }
+
+export type UpdateCommand<
+  Item extends object,
+  PartitionKey extends keyof Item,
+  RangeKey extends keyof Item | undefined,
+  Format extends JsonFormat
+> = new <
+  Key extends TableKey<Item, PartitionKey, RangeKey, Format>,
+  UpdateExpression extends string,
+  ConditionExpression extends string | undefined = undefined,
+  ReturnValue extends DynamoDBReturnValue = "NONE"
+>(
+  input: UpdateItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    UpdateExpression,
+    ConditionExpression,
+    ReturnValue,
+    Format
+  >
+) => Command<
+  UpdateItemInput<
+    Item,
+    PartitionKey,
+    RangeKey,
+    Key,
+    UpdateExpression,
+    ConditionExpression,
+    ReturnValue,
+    Format
+  >,
+  UpdateItemOutput<Item, PartitionKey, RangeKey, Key, ReturnValue, Format> &
+    MetadataBearer,
+  DynamoDBClientResolvedConfig
+> & {
+  _brand: "UpdateItemCommand";
+};

--- a/test/v3-document.test.ts
+++ b/test/v3-document.test.ts
@@ -1,14 +1,13 @@
 import "jest";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { TypeSafeGetItemCommand } from "../src/get-item-command";
-import { TypeSafeDeleteItemCommand } from "../src/delete-item-command";
-import { TypeSafePutItemCommand } from "../src/put-item-command";
-import { TypeSafeQueryCommand } from "../src/query-command";
-import { TypeSafeUpdateItemCommand } from "../src/update-item-command";
-import { JsonFormat } from "../src/json-format";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { TypeSafeDocumentClientV3 } from "../src/document-client-v3";
+import { TypeSafePutDocumentCommand } from "../src/put-document-command";
+import { TypeSafeUpdateDocumentCommand } from "../src/update-document-command";
+import { TypeSafeQueryDocumentCommand } from "../src/query-document-command";
+import { TypeSafeGetDocumentCommand } from "../src/get-document-command";
+import { TypeSafeDeleteDocumentCommand } from "../src/delete-document-command";
 
 interface MyType {
   key: string;
@@ -22,33 +21,26 @@ const docClient = DynamoDBDocumentClient.from(
   client
 ) as TypeSafeDocumentClientV3<MyType, "key", "sort">;
 
-const PutItemCommand = TypeSafePutItemCommand<MyType, JsonFormat.Document>();
-const UpdateItemCommand = TypeSafeUpdateItemCommand<
+const PutItemCommand = TypeSafePutDocumentCommand<MyType>();
+const UpdateItemCommand = TypeSafeUpdateDocumentCommand<
   MyType,
   "key",
-  "sort",
-  JsonFormat.Document
+  "sort"
 >();
-const GetItemCommand = TypeSafeGetItemCommand<
+const GetItemCommand = TypeSafeGetDocumentCommand<MyType, "key", "sort">();
+const DeleteItemCommand = TypeSafeDeleteDocumentCommand<
   MyType,
   "key",
-  "sort",
-  JsonFormat.Document
+  "sort"
 >();
-const DeleteItemCommand = TypeSafeDeleteItemCommand<
-  MyType,
-  "key",
-  "sort",
-  JsonFormat.Document
->();
-const QueryCommand = TypeSafeQueryCommand<MyType, JsonFormat.Document>();
+const QueryCommand = TypeSafeQueryDocumentCommand<MyType>();
 
-it("dummy", () => {
+it("dummy", async () => {
   expect(1).toBe(1);
 });
 
 export async function foo() {
-  const get = await client.send(
+  const get = await docClient.send(
     new GetItemCommand({
       TableName: "",
       Key: {
@@ -74,7 +66,7 @@ export async function foo() {
   // @ts-expect-error
   getDoc.Item?.list;
 
-  const put = await client.send(
+  const put = await docClient.send(
     new PutItemCommand({
       TableName: "",
       Item: {
@@ -96,7 +88,7 @@ export async function foo() {
   });
   putDoc.Attributes?.key;
 
-  const del = await client.send(
+  const del = await docClient.send(
     new DeleteItemCommand({
       TableName: "",
       Key: {
@@ -118,7 +110,7 @@ export async function foo() {
   });
   delDoc.Attributes?.key;
 
-  const query = await client.send(
+  const query = await docClient.send(
     new QueryCommand({
       TableName: "",
       KeyConditionExpression: "#key = :val",
@@ -148,7 +140,7 @@ export async function foo() {
 }
 
 export async function updateItem() {
-  const defaultBehavior = await client.send(
+  const defaultBehavior = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {
@@ -169,7 +161,7 @@ export async function updateItem() {
   // @ts-expect-error - default ReturnValues is None
   defaultBehavior.Attributes?.key;
 
-  const returnNone = await client.send(
+  const returnNone = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {
@@ -183,7 +175,7 @@ export async function updateItem() {
   // @ts-expect-error - nothing is Returned
   returnNone.Attributes?.key;
 
-  const returnAllNew = await client.send(
+  const returnAllNew = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {
@@ -196,7 +188,7 @@ export async function updateItem() {
   );
   returnAllNew.Attributes?.key?.length;
 
-  const returnAllOld = await client.send(
+  const returnAllOld = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {
@@ -209,7 +201,7 @@ export async function updateItem() {
   );
   returnAllOld.Attributes?.key?.length;
 
-  const returnUpdatedNew = await client.send(
+  const returnUpdatedNew = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {
@@ -222,7 +214,7 @@ export async function updateItem() {
   );
   returnUpdatedNew.Attributes?.key?.length;
 
-  const returnUpdatedOld = await client.send(
+  const returnUpdatedOld = await docClient.send(
     new UpdateItemCommand({
       TableName: "",
       Key: {


### PR DESCRIPTION
Fixes #33 

There was a bug in the V3 Commands for the Document Client. Instead of using the Command from `@aws-sdk/lib-dynamodb`, we were re-using the `@aws-sdk/client-dynamodb` Commands which expect the data to be in the Attribute Value format. This resulted in serialization errors.

See: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html for official documentation on how to use the DocumentClient with V3's AWS SDK.

This change adds new Commands specific to v3's document client. The new commands follow the naming convention: `TypeSafe*DocumentCommand`:
- GetItem - `TypeSafeGetDocumentCommand`
- PutItem - `TypeSafePutDocumentCommand`
- DeleteItem - `TypeSafeDeleteDocumentCommand`
- UpdateItem - `TypeSafeUpdateDocumentCommand`
- Query - `TypeSafeQueryDocumentCommand`
- Scan - `TypeSafeScanDocumentCommand`

Example:
```ts
import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
import { TypeSafeGetDocumentCommand } from "../src/get-document-command";

const client = new DynamoDBClient({});

const docClient = DynamoDBDocumentClient.from(
  client
);

const MyCommand = new TypeSafeGetDocumentCommand<Type, PK, SK>();

docClient.send(new MyCommand({
  ..
});
```

BREAKING CHANGE: JsonFormat removed from V3 command's type parameters 